### PR TITLE
feat: pluggable FHIR generator write target (XTDB | Postgres) + CDC

### DIFF
--- a/AWS Setup/Makefile
+++ b/AWS Setup/Makefile
@@ -36,6 +36,7 @@ CURRENT_ENV := $(shell cat .current-env 2>/dev/null)
         cdc-test-insert cdc-test-query \
         app-dep app-teardown app-logs xtdb-build xtdb-push xtdb-setup xtdb-upgrade xtdb-logs \
         gen-build gen-push gen-dep gen-logs gen-stat gen-setup gen-teardown cloud-logs \
+        pggen-dep pggen-logs pggen-stat pggen-setup pggen-teardown \
         log-dep log-logs log-stat log-teardown \
         chaos-install chaos-teardown chaos-apply chaos-delete chaos-status \
         scale-down scale-up
@@ -94,6 +95,11 @@ help:
 	@echo "  make gen-stat       - Show generator pod status"
 	@echo "  make gen-setup      - Full generator deployment (build + push + deploy)"
 	@echo "  make gen-teardown   - Remove generator deployment"
+	@echo "  make pggen-dep      - Deploy Postgres-target generator (writes to cdc db for CDC)"
+	@echo "  make pggen-logs     - View Postgres-target generator logs"
+	@echo "  make pggen-stat     - Show Postgres-target generator pod status"
+	@echo "  make pggen-setup    - Full Postgres-target deployment (shared build + push + deploy)"
+	@echo "  make pggen-teardown - Remove Postgres-target generator deployment"
 	@echo ""
 	@echo "Fluent Bit log forwarding (CloudWatch Logs):"
 	@echo "  make log-dep        - Deploy fluent-bit DaemonSet to amazon-cloudwatch ns"
@@ -603,6 +609,34 @@ gen-setup: gen-push gen-dep
 # Uninstall the generator
 gen-teardown:
 	@kubectl delete -f generator-deployment.yaml -n $(NAMESPACE) || true
+
+# ---- Postgres-target generator (second instance, same image, target=postgres) ----
+# Writes FHIR data into the Postgres 'cdc' db so it replicates into XTDB via CDC.
+# Reuses the shared gen-build/gen-push (one image); only the deployment differs.
+
+# Deploy the Postgres-target generator
+pggen-dep:
+	@echo "Deploying xtdb-fhir-generator-pg..."
+	@sed 's|IMAGE_PLACEHOLDER|$(ECR_GENERATOR_REPO):$(GENERATOR_TAG)|g' pg-generator-deployment.yaml | kubectl apply -f - -n $(NAMESPACE)
+	@kubectl rollout restart deployment/xtdb-fhir-generator-pg -n $(NAMESPACE)
+
+# View Postgres-target generator logs
+pggen-logs:
+	@kubectl logs -f -l app=xtdb-fhir-generator-pg -n $(NAMESPACE)
+
+# Show Postgres-target generator pod status
+pggen-stat:
+	@kubectl get pods -l app=xtdb-fhir-generator-pg -n $(NAMESPACE)
+
+# Full Postgres-target deployment (shared build + push + deploy)
+pggen-setup: gen-push pggen-dep
+	@echo "Postgres-target generator (probably) fully deployed!"
+	@sleep 15
+	@kubectl logs -f -l app=xtdb-fhir-generator-pg -n $(NAMESPACE)
+
+# Uninstall the Postgres-target generator
+pggen-teardown:
+	@kubectl delete -f pg-generator-deployment.yaml -n $(NAMESPACE) || true
 
 # ===========================================
 # Guardrails Deploy (monitoring daemon)

--- a/AWS Setup/Makefile
+++ b/AWS Setup/Makefile
@@ -71,8 +71,8 @@ help:
 	@echo "  make pg-teardown    - Uninstall PostgreSQL (PVC retained)"
 	@echo "  make cdc-start      - Set up the cdc database + attach pg_cdc in XTDB (starts CDC)"
 	@echo "  make cdc-stop       - Detach pg_cdc + drop the cdc database (stops CDC)"
-	@echo "  make cdc-test-insert - Insert a test row into Postgres core.foo (CDC smoke test)"
-	@echo "  make cdc-test-query  - Query XTDB pg_cdc core.foo to confirm it replicated"
+	@echo "  make cdc-test-insert - Insert a test Patient row into Postgres core.patient (CDC smoke test)"
+	@echo "  make cdc-test-query  - Query XTDB pg_cdc core.patient to confirm it replicated"
 	@echo ""
 	@echo "Legacy app deployment (batch importer from ECR):"
 	@echo "  make app-dep        - Deploy xtdb-fhir batch job via Helm"
@@ -470,14 +470,14 @@ cdc-start: cdc-setup cdc-attach
 cdc-stop: cdc-detach cdc-teardown
 	@echo "CDC replication stopped."
 
-# Smoke test: insert a marker row into Postgres core.foo (replicated via CDC)
+# Smoke test: insert a marker Patient row into Postgres core.patient (replicated via CDC)
 cdc-test-insert:
-	@echo "Inserting a test row into core.foo on the cdc database..."
+	@echo "Inserting a test Patient row into core.patient on the cdc database..."
 	@$(call pg-run,psql "host=localhost port=5433 user=postgres dbname=cdc" -v ON_ERROR_STOP=1 -f sql/cdc-test-insert.sql)
 
 # Smoke test: query XTDB's attached pg_cdc to confirm the row replicated
 cdc-test-query:
-	@echo "Querying core.foo on the XTDB pg_cdc database..."
+	@echo "Querying core.patient on the XTDB pg_cdc database..."
 	@$(call xtdb-run,psql "host=localhost port=5432 user=xtdb dbname=pg_cdc" -v ON_ERROR_STOP=1 -f sql/cdc-test-query.sql)
 
 # Connect to XTDB via port-forward (internal NLB not accessible from outside VPC)

--- a/AWS Setup/README.md
+++ b/AWS Setup/README.md
@@ -17,6 +17,28 @@ Run `make help` at any time to list the commands.
 The current environment (`dev` / `prod`) is stored in `.current-env` after a
 `make setup` run; targets that need it read from there, otherwise they prompt.
 
+### If using profile-based AWS auth
+
+The Makefile uses whatever AWS credentials are active — it doesn't pin a profile.
+If you authenticate with a named profile (e.g. `dan`), export it so every
+`aws …` call (including the `$(shell aws ecr …)` repo lookups, which otherwise
+resolve to `NOT_SET`) and `kubectl` (its exec auth runs `aws eks get-token`) pick
+it up:
+
+```sh
+export AWS_PROFILE=dan
+```
+
+Or pass it per-invocation — make forwards command-line vars into recipes and
+`$(shell …)`: `make gen-push AWS_PROFILE=dan`.
+
+If `kubectl` still can't authenticate, regenerate the kubeconfig with the profile
+baked into its exec block:
+
+```sh
+aws eks update-kubeconfig --name xtdb-cluster --region eu-west-1 --profile dan
+```
+
 ## Common configuration
 
 | Variable          | Default              | Description                                  |
@@ -101,8 +123,8 @@ the `postgresql` Secret password is injected into the XTDB pods as `PGUSER` /
 | `make pg-teardown`| Uninstall PostgreSQL (the PVC is retained)              |
 | `make cdc-start`  | Create the `cdc` database (schema/tables/publication) + attach `pg_cdc` in XTDB (starts CDC) |
 | `make cdc-stop`   | Detach `pg_cdc` + drop the `cdc` database (stops CDC) |
-| `make cdc-test-insert` | Insert a marker row into Postgres `core.foo` (CDC smoke test) |
-| `make cdc-test-query`  | Query XTDB `pg_cdc` `core.foo` to confirm the row replicated |
+| `make cdc-test-insert` | Insert a marker Patient row into Postgres `core.patient` (CDC smoke test) |
+| `make cdc-test-query`  | Query XTDB `pg_cdc` `core.patient` to confirm the row replicated |
 
 ### CDC replication (`cdc-start` / `cdc-stop`)
 
@@ -110,9 +132,15 @@ CDC has two sides, both driven from `.sql` files under [`sql/`](./sql/):
 
 - **Postgres** (`sql/cdc-setup.sql`, run against the default `postgres` db) —
   creates the `cdc` database if missing, then `\connect`s into it to create the
-  `core` schema, a placeholder `foo` table (PK named `_id`, which XTDB requires on
-  every replicated row; real schema TBD), and the `xtdb` publication
-  (`FOR TABLES IN SCHEMA core`). Idempotent — safe to re-run.
+  `core` schema, the resource-type tables the generator writes to (`core.patient`,
+  `core.observation`, … — flat schema, PK named `_id`, which XTDB requires on every
+  replicated row), and the `xtdb` publication (`FOR TABLES IN SCHEMA core`).
+  Idempotent — safe to re-run. The tables are pre-created here, *before* the attach,
+  on purpose: XTDB's initial snapshot only captures tables in the publication at
+  attach time, and a table that joins later has its pre-existing rows silently
+  dropped ([xtdb/xtdb#5497](https://github.com/xtdb/xtdb/issues/5497)). Pre-creating
+  them puts them in the snapshot; the generator's `CREATE TABLE IF NOT EXISTS` then
+  no-ops and it only ever *inserts*.
 - **XTDB** (`sql/attach-database.sql`) — `ATTACH DATABASE pg_cdc`, with the `cdc`
   remote as the `!Postgres` external source. The Kafka topics
   (`xtdb-pgcdc-sourceLog-*` / `xtdb-pgcdc-replicaLog-*`) and S3 prefix (`pg-cdc-*`)
@@ -126,13 +154,38 @@ targets — `cdc-setup`, `cdc-attach`, `cdc-detach`, `cdc-teardown` — are also
 available individually.
 
 To smoke-test the round-trip once CDC is running, `make cdc-test-insert` writes a
-timestamped marker row into Postgres `core.foo`, and `make cdc-test-query` reads
-the latest `core.foo` rows back from XTDB's attached `pg_cdc` database — the
-marker should appear there once replicated.
+marker Patient row into Postgres `core.patient` (its `status` carries a
+timestamp), and `make cdc-test-query` reads the latest `core.patient` rows back
+from XTDB's attached `pg_cdc` database — the marker should appear there once
+replicated.
+
+**Driving CDC with real FHIR data.** With CDC running, deploy the Postgres-target
+generator (`make pggen-setup` — see [Generator](#generator-synthea-data-generator)).
+It synthesises FHIR resources and upserts them into `cdc`, one flat table per
+resource type in `core` (`_id`, `resource_type`, `status`, `patient_id`,
+`encounter_id`, `code`, `last_updated`, `created_at` — a handful of promoted
+top-level fields, no jsonb), which CDC replicates into XTDB's `pg_cdc` database.
+Compare counts between the source and target to watch replication keep up:
+
+```sql
+-- Postgres (source), via `make pg-con` then `\c cdc`:
+SELECT count(*) FROM core.patient;
+-- XTDB (target), against the attached pg_cdc database
+-- (as `make cdc-test-query` does — psql … dbname=pg_cdc):
+SELECT count(*) FROM core.patient;
+```
+
+> Note: the curated tables in `cdc-setup.sql` cover the resource types Synthea
+> emits, so a normal run is fully snapshot-safe. If the generator ever writes a
+> resource type *not* in that list, its table is created after attach and is
+> subject to [#5497](https://github.com/xtdb/xtdb/issues/5497) (early rows may be
+> dropped). Add it to `cdc-setup.sql` and `make cdc-stop && make cdc-start` to
+> re-snapshot, or to recover an existing dataset re-attach captures everything
+> currently present.
 
 > Note: the publication name (`xtdb`) must match `publicationName` in
 > `sql/attach-database.sql`. The Postgres tables need a replica identity for
-> updates/deletes — the placeholder tables use a primary key, which covers it.
+> updates/deletes — the generator tables use a primary key (`_id`), which covers it.
 
 ## Legacy batch importer (xtdb-fhir)
 
@@ -144,15 +197,32 @@ marker should appear there once replicated.
 
 ## Generator (Synthea data generator)
 
-| Command            | Description                                       |
-|--------------------|---------------------------------------------------|
-| `make gen-build`   | Build the `xtdb-fhir-generator` Docker image      |
-| `make gen-push`    | Build and push the generator image to ECR         |
-| `make gen-dep`     | Deploy the generator as a long-running pod         |
-| `make gen-logs`    | View generator logs                               |
-| `make gen-stat`    | Show generator pod status                         |
-| `make gen-setup`   | Full generator deployment (build + push + deploy) |
-| `make gen-teardown`| Remove the generator deployment                   |
+The generator continuously synthesises FHIR data with Synthea and writes it out.
+A single image runs against either of two **write targets**, selected per
+deployment by the `patient-generator.target` property in its ConfigMap:
+
+- **`xtdb`** (`generator-deployment.yaml`) — writes straight to XTDB via
+  `INSERT … RECORDS`.
+- **`postgres`** (`pg-generator-deployment.yaml`) — writes into the `cdc`
+  Postgres database, which CDC replicates into XTDB. This is how we drive the
+  CDC path under load (see [CDC replication](#cdc-replication-cdc-start--cdc-stop)).
+
+Both share `gen-build` / `gen-push` (one image); only the deployment differs.
+
+| Command             | Description                                              |
+|---------------------|----------------------------------------------------------|
+| `make gen-build`    | Build the `xtdb-fhir-generator` Docker image             |
+| `make gen-push`     | Build and push the generator image to ECR                |
+| `make gen-dep`      | Deploy the XTDB-target generator                         |
+| `make gen-logs`     | View XTDB-target generator logs                          |
+| `make gen-stat`     | Show XTDB-target generator pod status                    |
+| `make gen-setup`    | Full XTDB-target deployment (build + push + deploy)      |
+| `make gen-teardown` | Remove the XTDB-target generator deployment             |
+| `make pggen-dep`    | Deploy the Postgres-target generator (writes to `cdc` for CDC) |
+| `make pggen-logs`   | View Postgres-target generator logs                      |
+| `make pggen-stat`   | Show Postgres-target generator pod status                |
+| `make pggen-setup`  | Full Postgres-target deployment (shared build + push + deploy) |
+| `make pggen-teardown` | Remove the Postgres-target generator deployment        |
 
 ## Guardrails (monitoring daemon)
 

--- a/AWS Setup/pg-generator-deployment.yaml
+++ b/AWS Setup/pg-generator-deployment.yaml
@@ -1,19 +1,20 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: xtdb-fhir-generator-config
+  name: xtdb-fhir-generator-pg-config
 data:
   application.yml: |
     patient-generator:
       population: 1
       interval-seconds: 10
-      # Write straight to XTDB via INSERT … RECORDS.
-      target: xtdb
+      # Write to Postgres (flat-column upsert into core.*); CDC replicates into XTDB.
+      target: postgres
 
     spring:
       datasource:
-        url: jdbc:postgresql://xtdb-service.xtdb-deployment.svc.cluster.local:5432/xtdb
-        username: xtdb
+        url: jdbc:postgresql://postgresql.xtdb-deployment.svc.cluster.local:5432/cdc
+        username: postgres
+        # password supplied via SPRING_DATASOURCE_PASSWORD env (from the postgresql Secret)
         hikari:
           connection-timeout: 11000
           maximum-pool-size: 10
@@ -33,16 +34,16 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: xtdb-fhir-generator
+  name: xtdb-fhir-generator-pg
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: xtdb-fhir-generator
+      app: xtdb-fhir-generator-pg
   template:
     metadata:
       labels:
-        app: xtdb-fhir-generator
+        app: xtdb-fhir-generator-pg
     spec:
       securityContext:
         runAsNonRoot: true
@@ -50,12 +51,17 @@ spec:
         runAsGroup: 1000
         fsGroup: 1000
       containers:
-        - name: xtdb-fhir-generator
+        - name: xtdb-fhir-generator-pg
           image: IMAGE_PLACEHOLDER
           imagePullPolicy: Always
           env:
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+            - name: SPRING_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql
+                  key: postgres-password
           resources:
             requests:
               memory: "2Gi"
@@ -94,7 +100,7 @@ spec:
           emptyDir: {}
         - name: app-config
           configMap:
-            name: xtdb-fhir-generator-config
+            name: xtdb-fhir-generator-pg-config
             items:
               - key: application.yml
                 path: application.yml

--- a/AWS Setup/sql/cdc-setup.sql
+++ b/AWS Setup/sql/cdc-setup.sql
@@ -1,12 +1,20 @@
 -- Postgres-side CDC setup, run against the default 'postgres' database.
 -- Creates the 'cdc' database if missing, then switches into it to create the
--- 'core' schema, a placeholder table, and the 'xtdb' publication that XTDB's
--- pg_cdc external source replicates from. Idempotent — safe to re-run.
+-- 'core' schema, the resource-type tables the generator writes to, and the 'xtdb'
+-- publication that XTDB's pg_cdc external source replicates from. Idempotent —
+-- safe to re-run.
 --
--- NOTE: the table schema here is a placeholder ('foo') — the real CDC tables
--- are TBD. 'FOR TABLES IN SCHEMA core' auto-includes any future tables added to
--- the schema (requires PostgreSQL 15+). The primary key is named '_id' because
--- XTDB requires an '_id' on every replicated row.
+-- Why pre-create the resource tables here (rather than let the generator's
+-- CREATE TABLE IF NOT EXISTS do it after attach): XTDB's initial CDC snapshot
+-- only captures tables present in the publication at attach time. A table that
+-- joins the publication afterwards has its pre-existing rows silently dropped —
+-- only later changes stream (see xtdb/xtdb#5497). Creating the tables here, before
+-- `cdc-attach`, puts them in the initial snapshot; the generator then only inserts
+-- into already-captured tables. 'FOR TABLES IN SCHEMA core' still auto-includes any
+-- other types the generator emits (PG15+), but those are subject to #5497.
+--
+-- The primary key is named '_id' because XTDB requires an '_id' on every
+-- replicated row; it also supplies the replica identity for updates/deletes.
 
 -- Create the 'cdc' database only when missing (\gexec runs nothing on no rows).
 SELECT 'CREATE DATABASE cdc'
@@ -17,11 +25,36 @@ WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'cdc')\gexec
 
 CREATE SCHEMA IF NOT EXISTS core;
 
-CREATE TABLE IF NOT EXISTS core.foo (
-    _id        bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    name       text,
-    created_at timestamptz NOT NULL DEFAULT now()
-);
+-- Resource-type tables, flat schema matching PostgresColumnWriter (a few promoted
+-- top-level FHIR fields, no jsonb). The list is the resource types Synthea emits;
+-- the generator's DDL no-ops against these. Created before attach so they land in
+-- the snapshot (xtdb/xtdb#5497).
+DO $$
+DECLARE
+    t text;
+    resource_tables text[] := ARRAY[
+        'allergy_intolerance', 'care_plan', 'care_team', 'claim', 'condition',
+        'coverage', 'device', 'diagnostic_report', 'encounter',
+        'explanation_of_benefit', 'imaging_study', 'immunization',
+        'medication_administration', 'medication_request', 'observation',
+        'organization', 'patient', 'practitioner', 'procedure',
+        'service_request', 'supply_delivery'
+    ];
+BEGIN
+    FOREACH t IN ARRAY resource_tables LOOP
+        EXECUTE format($ddl$
+            CREATE TABLE IF NOT EXISTS core.%I (
+                _id           text PRIMARY KEY,
+                resource_type text,
+                status        text,
+                patient_id    text,
+                encounter_id  text,
+                code          text,
+                last_updated  timestamptz,
+                created_at    timestamptz NOT NULL DEFAULT now()
+            )$ddl$, t);
+    END LOOP;
+END $$;
 
 -- Drop-then-create so cdc-start is idempotent (no CREATE PUBLICATION IF NOT EXISTS).
 DROP PUBLICATION IF EXISTS xtdb;

--- a/AWS Setup/sql/cdc-test-insert.sql
+++ b/AWS Setup/sql/cdc-test-insert.sql
@@ -1,6 +1,6 @@
 -- CDC smoke test (Postgres side), run against the 'cdc' database.
--- Inserts a marker row into core.foo so CDC replicates it into XTDB's pg_cdc.
--- The marker name carries a timestamp so cdc-test-query can spot the latest one.
-INSERT INTO core.foo (name)
-VALUES ('cdc-test ' || now())
-RETURNING _id, name, created_at;
+-- Inserts a marker Patient row into core.patient so CDC replicates it into XTDB's
+-- pg_cdc. The status carries a timestamp so cdc-test-query can spot the latest one.
+INSERT INTO core.patient (_id, resource_type, status, last_updated)
+VALUES (gen_random_uuid()::text, 'patient', 'cdc-test ' || now(), now())
+RETURNING _id, resource_type, status, last_updated, created_at;

--- a/AWS Setup/sql/cdc-test-query.sql
+++ b/AWS Setup/sql/cdc-test-query.sql
@@ -1,7 +1,7 @@
 -- CDC smoke test (XTDB side), run against the attached 'pg_cdc' database.
--- Shows the most recently replicated core.foo rows so you can confirm the
+-- Shows the most recently replicated core.patient rows so you can confirm the
 -- cdc-test-insert marker has landed via CDC.
-SELECT _id, name, created_at
-FROM core.foo
+SELECT _id, resource_type, status, last_updated, created_at
+FROM core.patient
 ORDER BY created_at DESC
 LIMIT 10;

--- a/xtdb-fhir/src/main/java/xtdb/fhir/FHIRImportService.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/FHIRImportService.java
@@ -5,17 +5,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
-import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
 import com.fasterxml.jackson.databind.node.*;
-import org.hl7.fhir.r4.model.DateTimeType;
-import org.postgresql.util.PGobject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +26,7 @@ public class FHIRImportService {
   private static final Logger logger = LoggerFactory.getLogger(FHIRImportService.class);
 
   private final DataSource dataSource;
+  private final ResourceWriter writer;
 
   // Statistics for logging
   private int filesProcessed = 0;
@@ -39,8 +36,9 @@ public class FHIRImportService {
   private int otherResourcesStored = 0;
   private int errors = 0;
 
-  public FHIRImportService(DataSource dataSource) {
+  public FHIRImportService(DataSource dataSource, ResourceWriter writer) {
     this.dataSource = dataSource;
+    this.writer = writer;
   }
 
   // =========================================================================
@@ -125,10 +123,7 @@ public class FHIRImportService {
     var resourcesByType = extractResourcesByType(bundle);
 
     for (var mapEntry : resourcesByType.entrySet()) {
-      var resourceType = mapEntry.getKey();
-      var resources = mapEntry.getValue();
-      insertBatch(conn, String.format("INSERT INTO %s RECORDS ?", resourceType), resources);
-      logger.debug("inserted {} resources of type {}", resources.size(), resourceType);
+      writer.writeBatch(conn, mapEntry.getKey(), mapEntry.getValue());
     }
   }
 
@@ -141,11 +136,6 @@ public class FHIRImportService {
 
       setReferenceAsId(resource, "subject");
       setReferenceAsId(resource, "patient");
-
-      JsonUtil.convertValues(resource, v -> {
-        var d = toJsonLdDateOrNull(v);
-        return d == null ? v : d;
-      });
 
       JsonUtil.convertKeysToSnakeCase(resource);
       resource.set("_id", resource.get("id")); // must be done after snake_case is applied to keys
@@ -189,68 +179,10 @@ public class FHIRImportService {
     return resourcesByType;
   }
 
-  private static ObjectNode toJsonLdDateOrNull(ValueNode v) {
-    if (v.isTextual()) {
-      try {
-        var asFhirDate = new DateTimeType(v.textValue());
-        if (asFhirDate.getPrecision() == TemporalPrecisionEnum.MONTH
-            || asFhirDate.getPrecision() == TemporalPrecisionEnum.DAY) {
-          var dateJsonLd = JsonNodeFactory.instance.objectNode();
-          dateJsonLd.set("@type", new TextNode("xt:date"));
-          dateJsonLd.set("@value", new TextNode(v.textValue()));
-          return dateJsonLd;
-        } else if (asFhirDate.getPrecision().ordinal() >= TemporalPrecisionEnum.MINUTE.ordinal()){
-          var dateJsonLd = JsonNodeFactory.instance.objectNode();
-          dateJsonLd.set("@type", new TextNode("xt:timestamptz"));
-          dateJsonLd.set("@value", new TextNode(v.textValue()));
-          return dateJsonLd;
-        }
-      } catch (ca.uhn.fhir.parser.DataFormatException ignored) {}
-    }
-    return null;
-  }
-
   private void setReferenceAsId(ObjectNode resource, String topProperty) {
     var subjectRef = JsonUtil.getText(resource, topProperty, "reference");
     if (subjectRef != null) {
       resource.set(topProperty + "_id", new TextNode(extractIdFromReference(subjectRef)));
-    }
-  }
-
-  // Max records per batch to stay under Kafka's 1MB message size limit.
-  // Some records (like imaging_study) can be very large (~50KB+), so use small batches.
-  private static final int MAX_BATCH_SIZE = 10;
-
-  /**
-   * Insert a batch of records using XTDB RECORDS syntax.
-   * Uses PGobject with "json" type for efficient JSON transfer.
-   * Splits into smaller chunks to avoid exceeding Kafka's max.request.size (1MB).
-   *
-   * @param conn The database connection
-   * @param sql The SQL statement for insertion
-   * @param records The list of records to insert
-   * @throws SQLException If there is a database error
-   */
-  private void insertBatch(Connection conn, String sql, List<JsonNode> records)
-      throws SQLException {
-    if (records.isEmpty()) return;
-
-    // Process in chunks to avoid exceeding Kafka's message size limit
-    for (int i = 0; i < records.size(); i += MAX_BATCH_SIZE) {
-      int end = Math.min(i + MAX_BATCH_SIZE, records.size());
-      List<JsonNode> chunk = records.subList(i, end);
-
-      try (PreparedStatement ps = conn.prepareStatement(sql)) {
-        for (var record : chunk) {
-          PGobject jsonObject = new PGobject();
-          jsonObject.setType("json");
-          jsonObject.setValue(record.toString());
-
-          ps.setObject(1, jsonObject);
-          ps.addBatch();
-        }
-        ps.executeBatch();
-      }
     }
   }
 
@@ -471,7 +403,7 @@ public class FHIRImportService {
     return null;
   }
 
-  String extractIdFromReference(String reference) {
+  static String extractIdFromReference(String reference) {
     if (reference.startsWith("urn:uuid:")) {
       return reference.substring("urn:uuid:".length());
     }

--- a/xtdb-fhir/src/main/java/xtdb/fhir/PatientGenerator.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/PatientGenerator.java
@@ -63,9 +63,10 @@ public class PatientGenerator implements AutoCloseable {
   private final int population;
 
   public PatientGenerator(HikariDataSource dataSource,
+                          ResourceWriter writer,
                           @Value("${patient-generator.population:2}") int population) {
     this.dataSource = dataSource;
-    this.importService = new FHIRImportService(dataSource);
+    this.importService = new FHIRImportService(dataSource, writer);
     this.population = population;
 
     // We better leave one connection idle for DataSource health checks to always succeed

--- a/xtdb-fhir/src/main/java/xtdb/fhir/PostgresColumnWriter.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/PostgresColumnWriter.java
@@ -1,0 +1,125 @@
+package xtdb.fhir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import xtdb.fhir.util.JsonUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Writes resources into PostgreSQL for CDC replication into XTDB: one table per
+ * resource type in the {@code core} schema (the publication scope), each row
+ * keyed by {@code _id}. Rather than carrying the full resource as jsonb (which we
+ * don't rely on replicating), a handful of top-level FHIR fields are promoted into
+ * flat typed columns that CDC handles cleanly. Upserts on {@code _id} to match
+ * XTDB RECORDS semantics. Tables are created on first sight of a resource type.
+ */
+public class PostgresColumnWriter implements ResourceWriter {
+
+  private static final Logger logger = LoggerFactory.getLogger(PostgresColumnWriter.class);
+
+  // Resource types whose table we've already ensured exists this process.
+  private final Set<String> ensured = ConcurrentHashMap.newKeySet();
+
+  @Override
+  public void writeBatch(Connection conn, String resourceType, List<JsonNode> resources)
+      throws SQLException {
+    if (resources.isEmpty()) return;
+
+    ensureTable(conn, resourceType);
+
+    String sql = "INSERT INTO core.\"" + resourceType
+        + "\" (_id, resource_type, status, patient_id, encounter_id, code, last_updated) "
+        + "VALUES (?, ?, ?, ?, ?, ?, ?::timestamptz) "
+        + "ON CONFLICT (_id) DO UPDATE SET "
+        + "resource_type = EXCLUDED.resource_type, status = EXCLUDED.status, "
+        + "patient_id = EXCLUDED.patient_id, encounter_id = EXCLUDED.encounter_id, "
+        + "code = EXCLUDED.code, last_updated = EXCLUDED.last_updated";
+
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      for (JsonNode record : resources) {
+        ps.setString(1, JsonUtil.getText(record, "_id"));
+        ps.setString(2, resourceType);
+        ps.setString(3, JsonUtil.getText(record, "status"));
+        ps.setString(4, patientId(record));
+        ps.setString(5, encounterId(record));
+        ps.setString(6, code(record));
+        setNullable(ps, 7, lastUpdated(record));
+        ps.addBatch();
+      }
+      ps.executeBatch();
+    }
+    logger.debug("upserted {} resources of type {} (postgres)", resources.size(), resourceType);
+  }
+
+  // One table per resource type, created on first sight. CREATE … IF NOT EXISTS
+  // is safe under concurrency; the in-process cache just avoids re-issuing DDL.
+  private void ensureTable(Connection conn, String resourceType) throws SQLException {
+    if (ensured.contains(resourceType)) return;
+    try (Statement st = conn.createStatement()) {
+      st.execute("CREATE SCHEMA IF NOT EXISTS core");
+      st.execute("CREATE TABLE IF NOT EXISTS core.\"" + resourceType + "\" ("
+          + "_id text PRIMARY KEY, "
+          + "resource_type text, "
+          + "status text, "
+          + "patient_id text, "
+          + "encounter_id text, "
+          + "code text, "
+          + "last_updated timestamptz, "
+          + "created_at timestamptz NOT NULL DEFAULT now())");
+    }
+    ensured.add(resourceType);
+  }
+
+  private static void setNullable(PreparedStatement ps, int idx, String value) throws SQLException {
+    if (value != null) {
+      ps.setString(idx, value);
+    } else {
+      ps.setNull(idx, Types.VARCHAR);
+    }
+  }
+
+  // patient_id convenience column: the patient/subject reference, already resolved
+  // to an id by the bundle extractor (setReferenceAsId).
+  private static String patientId(JsonNode record) {
+    String pid = JsonUtil.getText(record, "patient_id");
+    return pid != null ? pid : JsonUtil.getText(record, "subject_id");
+  }
+
+  // encounter_id convenience column: derived from the encounter reference if present.
+  private static String encounterId(JsonNode record) {
+    String ref = JsonUtil.getText(record, "encounter", "reference");
+    return ref != null ? FHIRImportService.extractIdFromReference(ref) : null;
+  }
+
+  // code column: the resource's primary code, preferring a SNOMED coding.
+  private static String code(JsonNode record) {
+    JsonNode coding = record.path("code").path("coding");
+    if (coding.isArray()) {
+      for (JsonNode c : coding) {
+        String system = JsonUtil.getText(c, "system");
+        if (system != null && system.contains("snomed")) {
+          return JsonUtil.getText(c, "code");
+        }
+      }
+      if (!coding.isEmpty()) {
+        return JsonUtil.getText(coding.get(0), "code");
+      }
+    }
+    return null;
+  }
+
+  // last_updated column: meta.lastUpdated (snake-cased to last_updated by the extractor).
+  private static String lastUpdated(JsonNode record) {
+    return JsonUtil.getText(record, "meta", "last_updated");
+  }
+}

--- a/xtdb-fhir/src/main/java/xtdb/fhir/ResourceWriter.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/ResourceWriter.java
@@ -1,0 +1,26 @@
+package xtdb.fhir;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Strategy for writing a batch of same-typed FHIR resources to a target store.
+ *
+ * Selected at runtime by the {@code patient-generator.target} property
+ * (see {@link WriterConfig}): {@link XtdbRecordsWriter} writes straight to XTDB,
+ * {@link PostgresJsonbWriter} writes to Postgres for CDC replication.
+ */
+public interface ResourceWriter {
+
+  /**
+   * Write a batch of resources of a single type using the given connection.
+   *
+   * @param conn         the database connection (transaction managed by the caller)
+   * @param resourceType the snake-cased FHIR resource type (the target table name)
+   * @param resources    the flattened resources to write (each carries an {@code _id})
+   */
+  void writeBatch(Connection conn, String resourceType, List<JsonNode> resources) throws SQLException;
+}

--- a/xtdb-fhir/src/main/java/xtdb/fhir/WriterConfig.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/WriterConfig.java
@@ -1,0 +1,29 @@
+package xtdb.fhir;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Selects the {@link ResourceWriter} from the {@code patient-generator.target}
+ * property ({@code xtdb} by default, or {@code postgres}). Set per-deployment via
+ * the app ConfigMap so the same image can run against either target.
+ */
+@Configuration
+public class WriterConfig {
+
+  private static final Logger log = LoggerFactory.getLogger(WriterConfig.class);
+
+  @Bean
+  public ResourceWriter resourceWriter(@Value("${patient-generator.target:xtdb}") String target) {
+    log.info("FHIR write target: {}", target);
+    return switch (target.toLowerCase()) {
+      case "xtdb" -> new XtdbRecordsWriter();
+      case "postgres" -> new PostgresColumnWriter();
+      default -> throw new IllegalArgumentException(
+          "Unknown patient-generator.target '" + target + "' (expected 'xtdb' or 'postgres')");
+    };
+  }
+}

--- a/xtdb-fhir/src/main/java/xtdb/fhir/XtdbRecordsWriter.java
+++ b/xtdb-fhir/src/main/java/xtdb/fhir/XtdbRecordsWriter.java
@@ -1,0 +1,90 @@
+package xtdb.fhir;
+
+import ca.uhn.fhir.model.api.TemporalPrecisionEnum;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import org.hl7.fhir.r4.model.DateTimeType;
+import org.postgresql.util.PGobject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import xtdb.fhir.util.JsonUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Writes resources straight into XTDB using its {@code INSERT … RECORDS} syntax:
+ * one table per resource type, schemaless documents keyed by {@code _id}.
+ * Applies XTDB's JSON-LD date coercion and chunks batches to stay under Kafka's
+ * 1MB message-size limit.
+ */
+public class XtdbRecordsWriter implements ResourceWriter {
+
+  private static final Logger logger = LoggerFactory.getLogger(XtdbRecordsWriter.class);
+
+  // Max records per batch to stay under Kafka's 1MB message size limit.
+  // Some records (like imaging_study) can be very large (~50KB+), so use small batches.
+  private static final int MAX_BATCH_SIZE = 10;
+
+  @Override
+  public void writeBatch(Connection conn, String resourceType, List<JsonNode> resources)
+      throws SQLException {
+    if (resources.isEmpty()) return;
+
+    // XTDB-specific: coerce date/time strings into XTDB JSON-LD typed values.
+    for (JsonNode resource : resources) {
+      JsonUtil.convertValues(resource, v -> {
+        var d = toJsonLdDateOrNull(v);
+        return d == null ? v : d;
+      });
+    }
+
+    String sql = String.format("INSERT INTO %s RECORDS ?", resourceType);
+
+    // Process in chunks to avoid exceeding Kafka's message size limit.
+    for (int i = 0; i < resources.size(); i += MAX_BATCH_SIZE) {
+      int end = Math.min(i + MAX_BATCH_SIZE, resources.size());
+      List<JsonNode> chunk = resources.subList(i, end);
+
+      try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        for (var record : chunk) {
+          PGobject jsonObject = new PGobject();
+          jsonObject.setType("json");
+          jsonObject.setValue(record.toString());
+
+          ps.setObject(1, jsonObject);
+          ps.addBatch();
+        }
+        ps.executeBatch();
+      }
+    }
+    logger.debug("inserted {} resources of type {} (xtdb)", resources.size(), resourceType);
+  }
+
+  private static ObjectNode toJsonLdDateOrNull(ValueNode v) {
+    if (v.isTextual()) {
+      try {
+        var asFhirDate = new DateTimeType(v.textValue());
+        if (asFhirDate.getPrecision() == TemporalPrecisionEnum.MONTH
+            || asFhirDate.getPrecision() == TemporalPrecisionEnum.DAY) {
+          var dateJsonLd = JsonNodeFactory.instance.objectNode();
+          dateJsonLd.set("@type", new TextNode("xt:date"));
+          dateJsonLd.set("@value", new TextNode(v.textValue()));
+          return dateJsonLd;
+        } else if (asFhirDate.getPrecision().ordinal() >= TemporalPrecisionEnum.MINUTE.ordinal()) {
+          var dateJsonLd = JsonNodeFactory.instance.objectNode();
+          dateJsonLd.set("@type", new TextNode("xt:timestamptz"));
+          dateJsonLd.set("@value", new TextNode(v.textValue()));
+          return dateJsonLd;
+        }
+      } catch (ca.uhn.fhir.parser.DataFormatException ignored) {}
+    }
+    return null;
+  }
+}

--- a/xtdb-fhir/src/main/resources/application.yml
+++ b/xtdb-fhir/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 patient-generator:
   population: 2
   interval-seconds: 10
+  # Write target: 'xtdb' (INSERT … RECORDS, default) or 'postgres' (jsonb for CDC).
+  target: xtdb
 
 logging:
   level:

--- a/xtdb-fhir/src/test/java/com/example/service/XTDBServiceTest.java
+++ b/xtdb-fhir/src/test/java/com/example/service/XTDBServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import xtdb.fhir.FHIRImportService;
+import xtdb.fhir.XtdbRecordsWriter;
 
 @Disabled
 // Integration tests for FHIRImportService with a real XTDB database running.
@@ -41,7 +42,7 @@ public class XTDBServiceTest {
       try (Connection conn = dataSource.getConnection()) {
         xtdbAvailable = conn.isValid(5);
       }
-      xtdbService = new FHIRImportService(dataSource);
+      xtdbService = new FHIRImportService(dataSource, new XtdbRecordsWriter());
     } catch (Exception e) {
       xtdbAvailable = false;
     }

--- a/xtdb-fhir/src/test/java/xtdb/fhir/ManualTests.java
+++ b/xtdb-fhir/src/test/java/xtdb/fhir/ManualTests.java
@@ -15,7 +15,7 @@ public class ManualTests {
 
   @Test
   void testImport(DataSource dataSource) throws Exception {
-    var importService = new FHIRImportService(dataSource);
+    var importService = new FHIRImportService(dataSource, new XtdbRecordsWriter());
     File file = new File(ClassLoader.getSystemResource("fhir_sample.json").toURI());
     var jsonNode = JsonUtil.parseFile(file);
     try (var conn = dataSource.getConnection()){


### PR DESCRIPTION
## What

Extends the existing Synthea FHIR generator so the **same image** can write to
either XTDB directly or to Postgres, and stands up a second deployment that feeds
Postgres to exercise the **CDC** path (Postgres → `pg_cdc` → XTDB) under load.

## How it works

**Pluggable write target.** A `ResourceWriter` interface is selected by the
`patient-generator.target` property (`xtdb` | `postgres`):

- `XtdbRecordsWriter` — `INSERT … RECORDS`; owns the XTDB-only `xt:date`/
  `xt:timestamptz` coercion and Kafka-size chunking.
- `PostgresColumnWriter` — one flat table per resource type in the `core` schema.
  Rather than carry the full resource as `jsonb`, a few top-level FHIR fields are
  promoted into typed columns (`_id`, `resource_type`, `status`, `patient_id`,
  `encounter_id`, `code`, `last_updated`, `created_at`); upsert on `_id`. CDC then
  replicates clean `text`/`timestamptz` columns.

`FHIRImportService.extractResourcesByType` stays the shared transform and
delegates the write to the injected writer.

**Two deployments, one image.** `generator-deployment.yaml` is pinned to
`target: xtdb`; `pg-generator-deployment.yaml` runs `target: postgres` against the
`cdc` database (password from the `postgresql` Secret). New `pggen-*` Make targets
reuse the shared `gen-build`/`gen-push`.

**CDC tables are pre-created before attach (xtdb/xtdb#5497).** XTDB's initial CDC
snapshot only captures tables present in the publication at attach time; a table
that joins later has its pre-existing rows silently dropped, with no warning. So
`cdc-setup.sql` now creates the resource-type tables (flat schema) *before*
`cdc-attach` — the generator's `CREATE TABLE IF NOT EXISTS` then no-ops and only
inserts. The smoke test (`cdc-test-insert`/`query`) now uses a real `core.patient`
row instead of the old placeholder `foo` table.

## Running it

```sh
make cdc-start            # creates cdc db + tables, attaches pg_cdc
make cdc-test-insert      # marker Patient row → core.patient
make cdc-test-query       # confirm it replicated into pg_cdc
make pggen-setup          # build + push + deploy the Postgres-target generator
```

Compare `count(*)` on `core.patient` between the `cdc` db and the attached
`pg_cdc` db to watch replication keep up. See the
[AWS Setup README](./AWS%20Setup/README.md#cdc-replication-cdc-start--cdc-stop)
for the full workflow and profile-based AWS auth notes.

## Validation

Verified end-to-end against the live EKS cluster: CDC smoke test round-trips, and
the Postgres-target generator writes all 21 Synthea resource types into `core.*`
for replication.

## Commits

1. `feat: pre-create CDC resource tables before attach (xtdb#5497)`
2. `feat: pluggable FHIR write target (xtdb | postgres)`
3. `feat: dual generator deployments + pggen targets`
4. `docs: AWS profile auth + CDC/generator README`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
